### PR TITLE
Fix: don't skip notification when tab title has spinner

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Request Copilot code review
-        run: gh pr edit "$PR_NUMBER" --add-reviewer copilot
+        run: gh pr edit "$PR_NUMBER" --add-reviewer copilot --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# streamdeck-iterm-tabs
+
+## Logs
+
+Plugin logs (use for debugging attention/notification issues):
+```
+~/Library/Application Support/com.elgato.StreamDeck/Plugins/com.iammikec.iterm-tabs.sdPlugin/logs/com.iammikec.iterm-tabs.0.log
+```
+
+Stream Deck app logs (startup, plugin connect/disconnect):
+```
+~/Library/Logs/ElgatoStreamDeck/StreamDeck.log
+```
+
+## Deploying changes
+
+Editing source files is not enough. Build and restart with:
+```bash
+npm run build && pkill -x "Stream Deck" && sleep 2 && open -a "Elgato Stream Deck"
+```

--- a/README.md
+++ b/README.md
@@ -65,13 +65,17 @@ The results are combined to determine what program each tab is running (by match
 
 ### Attention detection
 
-The plugin monitors the macOS unified log via `log stream` for notification deliveries from iTerm2. When a notification fires:
+Two strategies run in parallel, depending on the tab.
 
-1. A detection window opens (4 polls / ~12 seconds).
-2. Any background tab that transitions from "processing" to idle, or from "not at shell prompt" to "at shell prompt" during this window gets flagged.
-3. The active tab is only excluded if iTerm2 is the frontmost app. When iTerm2 is backgrounded, all tabs are eligible.
+**Title-based detection (Claude Code tabs)**
 
-This approach avoids false positives from silence-based heuristics while still catching real "needs input" events.
+Claude Code sets the terminal title via OSC escape sequences - a braille spinner character while working, and a done marker (✳ ✻ ✽ ✶ ✢) when it finishes and is waiting for input. The plugin reads these from the iTerm2 session name on every poll. When the spinner disappears or a done marker first appears, the tab is flagged. When a new spinner appears (you responded and Claude started working), the flag clears.
+
+This works with both auto-named and manually renamed tabs. If you use Claude Code's `/rename` command to give a session a custom name, the spinner and done marker characters are still present in the title alongside your name, so detection continues to work.
+
+**Notification-based detection (all other tabs)**
+
+The plugin monitors the macOS unified log via `log stream` for notification deliveries from iTerm2 and HeyAgent. When a notification fires and can be matched to a tab by TTY, that tab is flagged if it was recently active. The active tab is only excluded if iTerm2 is the frontmost app.
 
 ### Button rendering
 
@@ -117,9 +121,9 @@ export ITERM_TABS_NOTIFICATION_MATCHERS="com.googlecode.iterm2,heyagent,HeyAgent
 
 ### HeyAgent + Codex (and Claude)
 
-If you use HeyAgent to wrap Codex or Claude Code, the default matchers already include `heyagent`, so notifications will trigger the same attention highlight as iTerm2’s built‑in notifications. This is most useful for Codex, which doesn’t emit BEL notifications by default.
+If you use HeyAgent to wrap Codex or Claude Code, the default matchers already include `heyagent`, so notifications will trigger the same attention highlight as iTerm2's built-in notifications. This is most useful for Codex, which doesn't emit BEL notifications by default.
 
-For Codex, HeyAgent is effectively required if you want reliable attention highlights. If you run `codex` directly, iTerm2 usually won’t post a macOS notification, so this plugin won’t get the signal to highlight the tab unless you add custom iTerm2 Triggers.
+For Codex, HeyAgent is effectively required if you want reliable attention highlights. If you run `codex` directly, iTerm2 usually won't post a macOS notification, so this plugin won't get the signal to highlight the tab unless you add custom iTerm2 Triggers.
 
 Recommended setup for Codex:
 1. Install HeyAgent globally (`npm install -g heyagent`).
@@ -134,7 +138,7 @@ If you want HeyAgent notifications to be silent and invisible while still trigge
 - **iTerm2 only** - no support for Terminal.app, Alacritty, Kitty, etc.
 - **Single window** - only monitors `window 1` of iTerm2. Multiple windows are not supported.
 - **Polling latency** - button updates take ~1 second (AppleScript overhead) plus up to 3 seconds between polls. Notifications trigger an immediate poll, but `log stream` buffering adds 1-3 seconds of delay.
-- **Notification-dependent attention** - attention highlighting only triggers when iTerm2 posts a macOS notification (typically via BEL character from CLI tools like Claude Code). Conversational prompts that don't send BEL won't trigger highlights. Adding iTerm2 Triggers for specific prompt patterns could help here.
+- **Notification-dependent attention (non-Claude tabs)** - for tabs not running Claude Code, attention highlighting requires a macOS notification from iTerm2 or HeyAgent. Conversational prompts that don't send BEL won't trigger highlights. Adding iTerm2 Triggers for specific prompt patterns could help here.
 - **Notification sounds** - iTerm2 notification sounds are controlled at the macOS level (System Settings > Notifications > iTerm2), not by this plugin. You can disable sounds while keeping notifications enabled, and the plugin will still detect them via the system log.
 
 ## Future work

--- a/src/actions/iterm-tab.ts
+++ b/src/actions/iterm-tab.ts
@@ -622,16 +622,7 @@ function updateAttention(tabInfo: TabInfo): void {
 				const tabIdx = ttyMatch + 1;
 				const isProc = tabInfo.processing[ttyMatch] ?? false;
 				const wasProcessing = prevProcessingState.get(tabIdx) ?? false;
-				const currentName = tabInfo.names[ttyMatch] ?? "";
-				const hasTitleSignal =
-					hasBrailleSpinner(currentName) || hasDoneMarker(currentName) ||
-					(prevTitleHadSpinner.get(tabIdx) ?? false) ||
-					(prevTitleHadDone.get(tabIdx) ?? false);
-				if (hasTitleSignal) {
-					streamDeck.logger.info(
-						`Tab ${tabIdx} skipped: TTY match but title detection is active`
-					);
-				} else if (tabIdx !== visibleTab && (isProc || wasProcessing)) {
+				if (tabIdx !== visibleTab && (isProc || wasProcessing)) {
 					attentionTabs.add(tabIdx);
 					streamDeck.logger.info(
 						`Tab ${tabIdx} flagged: TTY match ${notificationEvent.tty} (processing=${isProc}, wasProcessing=${wasProcessing})`

--- a/src/actions/iterm-tab.ts
+++ b/src/actions/iterm-tab.ts
@@ -688,19 +688,26 @@ function updateAttention(tabInfo: TabInfo): void {
 			streamDeck.logger.info(
 				`Tab ${tabIdx} attention cleared: spinner appeared (Claude responding)`
 			);
-		} else if (isProcessing && !wasProcessing && attentionTabs.has(tabIdx)) {
-			// Fallback clear for non-title tabs: started processing
+		} else if (isProcessing && !wasProcessing && attentionTabs.has(tabIdx) && !titleDetectionActive) {
+			// Fallback clear for non-title tabs only: started processing
 			attentionTabs.delete(tabIdx);
 			streamDeck.logger.info(
 				`Tab ${tabIdx} attention cleared: new processing started`
 			);
 		} else if (pollCount > 0) {
-			// Title-based (Claude Code auto-named tabs): spinner disappeared = finished
-			if (titleDetectionActive && prevHadSpinner && !titleHasSpinner) {
-				attentionTabs.add(tabIdx);
-				streamDeck.logger.info(
-					`Tab ${tabIdx} flagged: spinner stopped (done=${titleHasDone})`
-				);
+			// Title-based detection: flag when spinner disappears or done marker first appears
+			if (titleDetectionActive) {
+				if (prevHadSpinner && !titleHasSpinner) {
+					attentionTabs.add(tabIdx);
+					streamDeck.logger.info(
+						`Tab ${tabIdx} flagged: spinner stopped (done=${titleHasDone})`
+					);
+				} else if (!prevHadDone && titleHasDone) {
+					attentionTabs.add(tabIdx);
+					streamDeck.logger.info(
+						`Tab ${tabIdx} flagged: done marker appeared`
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Removes the `hasTitleSignal` guard that was skipping TTY-matched notifications when a braille spinner was present in the tab title
- Claude Code can send a notification while still showing a spinner (e.g. waiting for input), causing both the notification path and the title-based path to miss it — this fixes that gap

## Test plan
- [ ] Trigger a Claude Code notification while the tab is still showing a spinner (e.g. permission request mid-task)
- [ ] Confirm the Stream Deck button lights up as expected
- [ ] Confirm tabs that respond quickly (idle at notification time) are still skipped